### PR TITLE
HTTPS rather than SSH for install git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ usage
 1. Clone `git-cheat` with:
 
 ```
-git clone git@github.com:0xAX/git-cheat.git
+git clone https://github.com/0xAX/git-cheat.git
 ```
 
 2. Install it to any place which is in your `$PATH`
@@ -82,7 +82,7 @@ todo
 contribution
 ------------
 
-if I missed something you can easily to contribute to `git-cheat`:
+If I missed something you can easily to contribute to `git-cheat`:
 
   * Fork [repo](https://github.com/0xAX/git-cheat)
   * Make you changes


### PR DESCRIPTION
I could be wrong, but I believe that Windows does not have SSH installed by default. Would it not make sense to recommend that git newbies try the HTTP method, as this does not have the SSH dependency?

Cheers,
Louis
